### PR TITLE
chore(repo): organizar documentação e preparar monorepo para desenvolvimento

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# e-commerce
-Creating a professional e-commerce with microservices architecture using Prisma, Fastify, NodeJS, and TypeScript 
+# E‑Commerce Pro — Backend (Monorepo)
+
+**Resumo rápido**
+Projeto backend para um e‑commerce profissional (monorepo). Objetivo: construir um backend robusto e bem documentado usando Yarn workspaces e Prisma — este repositório serve como projeto de portfólio e referência técnica.
+
+---
+
+## Estado atual
+
+- **Status:** Planeamento e documentação completas (Sprints 0–8).
+- **Código:** Ainda não implementado (sem migrations aplicadas, sem serviços em código).
+- **O que já existe:** ADRs, ER do catálogo, contratos textuais, seeds de exemplo, templates de PR/Issue, project board e planos de sprints. Tudo em `docs/`, `ecommerce_issues/` e `docs/sprints/`.
+
+---
+
+## Objetivo deste README
+
+Dar um mapa rápido e accionável para qualquer pessoa (ou tu) começar a trabalhar e transformar a documentação em código com segurança e ordem.
+
+---
+
+## Como começar (quick start)
+
+1. Cria uma branch de setup localmente:
+   - `git checkout -b feature/setup-monorepo`
+2. Confirma que tens os ficheiros importantes (ex.: `docs/README-setup.md`, `docs/er/catalog.md`, `docs/seeds.md`, `.github/PULL_REQUEST_TEMPLATE.md`).
+3. Adiciona tudo e faz o commit com a mensagem recomendada (já gerada), por exemplo:
+   - `git add -A && git commit -m "chore(repo): organizar documentação e preparar monorepo para desenvolvimento"`
+4. Push e abre um PR de preparação (`feature/setup-monorepo -> main`) usando o PR body em `docs/PR_BODY_feature-setup-monorepo.md` (ou o ficheiro `docs/PR_BODY_feature-setup-monorepo.md` existente).
+5. Após merge: criar branch `feature/catalog-modeling` e seguir a sprint 1 (modelagem do catálogo).
+
+> Observação: os ficheiros `docs/project_board.md` e `docs/sprints/` contêm a lista de tarefas e documentos detalhados para cada sprint.
+
+---
+
+## Estrutura principal do repositório (visão)
+
+```
+/docs                     # Documentação canónica (ADRs, ER, prisma, seeds, sprints)
+/docs/adrs                # ADRs (decisões arquiteturais)
+/docs/er                  # ER do catálogo (catalog.md)
+/docs/sprints             # Documentos detalhados por sprint (sprint2...sprint8)
+/ecommerce_issues         # Issues em markdown (usar no project board)
+/sprint1_details          # Artefatos da Sprint 1 (contratos, índices, testes)
+/services                 # Serviços do monorepo (skeletons com README)
+/libs                     # Bibliotecas partilhadas (skeleton)
+/.github                  # Template de PR padrão do repositório
+README.md                 # (este ficheiro)
+LICENSE
+```
+
+---
+
+## Documentos mais importantes (ler primeiro)
+
+1. `docs/README-setup.md` — guia de instalação e configuração (alto nível).
+2. `docs/er/catalog.md` — modelagem do catálogo (campos, índices, queries).
+3. `docs/seeds.md` — seeds de desenvolvimento (10 produtos, 3 categorias).
+4. `docs/prisma.md` — política de migrations e boas práticas.
+5. `docs/project_board.md` — Kanban pronto para colar no GitHub Projects.
+6. `docs/sprints/*` — documentação detalhada por sprint (2→8).
+
+---
+
+## Workflow e convenções
+
+- **Branches:** `feature/*`, `hotfix/*`, `release/*`.
+- **Commits:** use _conventional commits_ (ex.: `feat(...)`, `fix(...)`, `chore(...)`).
+- **PRs:** usar o template em `.github/PULL_REQUEST_TEMPLATE.md`. Incluir link para issue e checklist.
+- **Yarn & Monorepo:** planejamento para usar _yarn workspaces_ (documentado no README-setup).
+- **Prisma:** migrations por feature; usar ambiente ephemeral no CI; seeds idempotentes. Veja `docs/prisma.md`.
+
+---
+
+## Primeiros passos recomendados (práticos)
+
+1. Abrir PR de setup (`feature/setup-monorepo`) com toda a documentação consolidada.
+2. Iniciar `feature/catalog-modeling`: finalizar `docs/er/catalog.md` e `docs/seeds.md` (1–2 horas).
+3. Após aprovação, criar branch `feature/catalog-migrations` e gerar migrations (este passo envolve código).
+
+---
+
+## Notas sobre segurança e operações
+
+- Não comitar segredos (`.env`). Use `.env` local e variables em CI.
+- Para produção, tenha backups antes de migrations destrutivas. Veja `docs/prisma.md` para detalhes.

--- a/docs/adrs/ADR-001-database-unico-vs-multidb.md
+++ b/docs/adrs/ADR-001-database-unico-vs-multidb.md
@@ -1,0 +1,30 @@
+# ADR 001 — Database: iniciar com DB único
+
+- **Data:** 2025-09-10  
+- **Status:** Aprovado  
+- **Autores:** Analista (assistente) & Desenvolvedor (você)
+
+## Contexto
+Para acelerar desenvolvimento, reduzir complexidade operacional e facilitar queries que cruzam entidades (ex.: product + order reports), precisamos decidir a topologia de bancos. Opções: um único banco PostgreSQL partilhado entre serviços (DB único) ou bancos separados por serviço (multi-DB).
+
+## Decisão
+**Iniciar com um DB único (PostgreSQL)** durante as fases iniciais (Sprint0 → Sprint4). Migrar para multi-DB caso a necessidade de isolamento, compliance ou escala justifique o custo operacional.
+
+## Justificativa
+- Facilita desenvolvimento local e CI (migrations e seeds mais simples).  
+- Evita a sobrecarga operativa de gerir múltiplas instâncias durante o desenvolvimento e fase de portfólio.  
+- Permite consultas e relatórios que juntam dados de vários domínios sem necessidade de pipelines de sincronização.
+
+## Consequências
+**Vantagens**
+- Menos infra inicial — mais rápido para demonstrar valor no portfólio.  
+- Migrations e backups centralizados — operação mais simples.
+
+**Desvantagens**
+- Acoplamento entre serviços; risco de dependências cruzadas (serviços a aceder tabelas de outros serviços).  
+- Escalabilidade e isolamento mais difíceis; eventual necessidade de migração para multi-DB (operacionalmente custosa).
+
+## Mitigações / Próximos passos
+- Definir regras claras: cada serviço só acede às tabelas que lhe pertencem (disciplina de código).  
+- Documentar criteria para migrar para multi-DB (ex.: taxa de QPS, requisitos de compliance, problemas de contenção).  
+- Usar schemas dentro do mesmo Postgres para isolar namespaces se necessário como passo intermédio.

--- a/docs/adrs/ADR-002-estrategia-reserva-stock.md
+++ b/docs/adrs/ADR-002-estrategia-reserva-stock.md
@@ -1,0 +1,31 @@
+# ADR 002 — Estratégia de reserva de stock
+
+- **Data:** 2025-09-10  
+- **Status:** Aprovado  
+- **Autores:** Analista & Desenvolvedor
+
+## Contexto
+Durante o checkout concorrente (vários clientes comprando o mesmo SKU), é crítico evitar oversell (venda de stock inexistente). Precisamos de uma estratégia que equilibre consistência e performance.
+
+## Decisão
+**Implementar inicialmente Optimistic Concurrency + reservas temporárias em Redis com TTL.**  
+Usar uma coluna `version` (ou `updatedAt`) no registro de stock para checagens de versão em updates críticos; manter reservas em Redis (key por sku+orderId) com TTL para expirar reservas não confirmadas. Se necessário, usar locks pessimistas (`SELECT FOR UPDATE`) em operações críticas específicas.
+
+## Justificativa
+- Optimistic concurrency evita locks de longa duração e funciona bem com carga moderada.  
+- Redis permite reservar rapidamente sem bloquear o banco e facilita expiração automática de reservas.  
+- Combinação permite performance em pico, com jobs periódicos para reconciliar reservas expiradas.
+
+## Consequências
+**Vantagens**
+- Boa performance e escalabilidade inicial.  
+- Menor contenção no banco, menos risco de deadlocks.
+
+**Desvantagens**
+- Complexidade operacional (reconciliação entre Redis e Postgres).  
+- Possível necessidade de lidar com edge-cases (reservas expiradas vs pagamentos em curso).
+
+## Mitigações / Próximos passos
+- Implementar job de reconciliação (worker) que liberte reservas expiradas e corrija contagens.  
+- Garantir idempotência nos handlers de confirmação de pagamento para converter reservas em decrementos definitivos.  
+- Documentar fluxos e criar testes que simulem concorrência.

--- a/docs/adrs/ADR-003-search-postgres-vs-elastic.md
+++ b/docs/adrs/ADR-003-search-postgres-vs-elastic.md
@@ -1,0 +1,30 @@
+# ADR 003 — Search: Postgres full-text (início) vs ElasticSearch (futuro)
+
+- **Data:** 2025-09-10  
+- **Status:** Aprovado (abordagem incremental)  
+- **Autores:** Analista & Desenvolvedor
+
+## Contexto
+Requisitos de pesquisa podem evoluir: desde simples buscas por nome/descrição até relevância avançada, faceting, sugestões e alta escala. Precisamos escolher uma solução inicial que minimize infra, porém permita evolução.
+
+## Decisão
+**Começar com Postgres full-text (tsvector + GIN/trigram indexes) e evoluir para ElasticSearch se e quando os requisitos/volume exigirem.** Implementar um conector/event forwarder que possa replicar documentos para Elastic no futuro.
+
+## Justificativa
+- Postgres full-text é suficiente para MVP e reduz infra e complexidade.  
+- Facilita gerenciamento em dev/CI e usa tecnologia já presente (Postgres).  
+- Planejar desde já a arquitetura para sincronização para reduzir custo de adoção de Elastic mais tarde.
+
+## Consequências
+**Vantagens**
+- Menor custo inicial; menos componentes para manter.  
+- Indexes e triggers podem ser ajustados sem grande rework do schema.
+
+**Desvantagens**
+- Menos recursos avançados de ranking / faceting / suggest do que Elastic.  
+- Potencial necessidade de migração caso escala e funcionalidades exijam.
+
+## Mitigações / Próximos passos
+- Documentar quais campos entrarão no tsvector e como serão atualizados.  
+- Implementar abstração de search no serviço (interface) de modo a permitir swap do backend de search.  
+- Monitorar métricas de queries/search (latência, erro, throughput) e acordar thresholds para avaliar migração.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,47 @@
+# docs/ci.md
+
+## Objetivo
+Descrever o pipeline CI/CD recomendado em alto nível. Este documento foca passos, gatilhos e práticas — sem fornecer ficheiros de pipeline prontos.
+
+## Princípios
+- **Pipeline por PR:** cada PR roda checks automáticos (lint, typecheck, unit tests). PRs não devem ser mergeados sem que o pipeline passe.
+- **Isolamento de ambiente:** usar DB ephemeral no CI para testes de integração; não compartilhar bases entre jobs.
+- **Fail fast:** detectar erros logo nas primeiras etapas (lint/typecheck) para poupar recursos.
+
+## Pipeline sugerido (PR)
+1. Checkout do código.
+2. Yarn install (workspaces) — instalar dependências.
+3. Lint (ESLint/format) e style checks.
+4. Typecheck (TypeScript) — falhar cedo se types estiverem inconsistentes.
+5. Unit tests e coverage.
+6. Build artifacts (opcional para validação).
+7. Migration dry-run / aplicar migrations no DB ephemeral.
+8. Integration tests (para serviços modificados).
+9. Report de resultados e artefatos de logs.
+
+## Pipeline sugerido (main / release)
+1. Executar steps do PR.
+2. Build de images Docker (por serviço) e tag com sha do commit.
+3. Push para registry (privado/public).
+4. Deploy automático para staging (via Helm/Terraform/flux/arbitrary).
+5. Rodar smoke tests e E2E em staging.
+6. Aprovação manual (se política exigir).
+7. Deploy para produção (após checks); aplicar migrations com backup.
+
+## Gatilhos
+- **PR:** run completo (itemized above).
+- **Push para main:** build + deploy para staging + smoke tests.
+- **Tag de release / manual:** deploy para produção.
+
+## Segurança e segredos
+- Guardar segredos no Secrets Manager / CI secrets (não commit no repo).
+- Acesso a registries e infra via roles com permissões mínimas.
+
+## Artifacts e logs
+- Armazenar artefatos de build (images, build logs) com referências ao commit.
+- Expor logs e test reports de forma acessível no job do CI.
+
+## Boas práticas
+- Jobs paralelos para velocidade (lint, typecheck e unit tests em paralelo).
+- Jobs longos (integration/E2E) apenas após steps rápidos passarem.
+- Mantenha o pipeline legível e versionado (scripts documentados).

--- a/docs/ecommerce_issues/sprint0-01-inicializar-monorepo.md
+++ b/docs/ecommerce_issues/sprint0-01-inicializar-monorepo.md
@@ -1,0 +1,21 @@
+# [Sprint0] Inicializar monorepo — Yarn workspaces & convenções
+
+**Descrição (contexto / porquê):**  
+Precisamos de uma estrutura que suporte vários serviços (Catalog, Orders, Auth, Payments) e bibliotecas compartilhadas. Isto facilita versionamento, reuso de código e pipelines unificados.
+
+**Objetivo:**  
+Criar a estrutura `services/`, `libs/`, `web/` e documentar convenções de naming, scripts e fluxo de desenvolvimento.
+
+**Critérios de aceitação:**  
+- README principal descreve a estrutura do monorepo;  
+- Exemplo de `package.json` na raiz com workspaces listados;  
+- Lista de scripts padrões (`install`, `dev`, `build`, `test`, `lint`) documentada.
+
+**Dependências:** nenhuma.
+
+**Estimativa:** 6 horas.
+
+**Notas adicionais / checklist:**  
+- Definir convenção de nomes para pacotes e pastas.  
+- Definir política de versionamento (semver) e publishing (quando aplicável).  
+- Documentar fluxo de branch e PR (ex.: feature/*, fix/*, release/*).  

--- a/docs/ecommerce_issues/sprint0-02-adrs-iniciais.md
+++ b/docs/ecommerce_issues/sprint0-02-adrs-iniciais.md
@@ -1,0 +1,26 @@
+# [Sprint0] ADRs iniciais — decisões arquiteturais prioritárias
+
+**Descrição:**  
+Registrar e justificar 3 ADRs: 1) DB único vs multi-DB; 2) Estratégia de reserva de stock; 3) Escolha de search engine.
+
+**Objetivo:**  
+Tomar decisões documentadas que sirvam como contrato para o time.
+
+**Critérios de aceitação:**  
+- 3 ADRs criados no diretório `docs/adr/` com template (context, decisão, consequências);  
+- ADRs revisados e aprovados pelo analista e pelo desenvolvedor.
+
+**Dependências:** issue #1.
+
+**Estimativa:** 4 horas.
+
+**Sugestão de template ADR (resumo):**  
+- Título: ADR XXX — [tema]  
+- Contexto: descrição do problema/pressupostos;  
+- Decisão: o que foi decidido;  
+- Consequências: trade-offs e próximos passos.
+
+**ADRs a criar (sugeridos):**  
+- ADR 001 — Database: único DB vs múltiplos DBs (decisão: iniciar com DB único).  
+- ADR 002 — Estratégia de reserva de stock (decisão: optimistic concurrency + reservas em Redis com TTL).  
+- ADR 003 — Search engine (decisão: iniciar com Postgres full-text, possibilitar Elastic no futuro).  

--- a/docs/ecommerce_issues/sprint0-03-configurar-ambiente-local.md
+++ b/docs/ecommerce_issues/sprint0-03-configurar-ambiente-local.md
@@ -1,0 +1,21 @@
+# [Sprint0] Configurar ambiente local (docker-compose alto nível)
+
+**Descrição:**  
+Documento de alto nível que descreve os serviços necessários para dev local: Postgres, Redis, serviço mock do catalog (opcional), variáveis de ambiente necessárias e volumes.
+
+**Objetivo:**  
+Permitir que qualquer dev consiga rodar o backend localmente com mínima fricção.
+
+**Critérios de aceitação:**  
+- Documento `docs/dev-local.md` com instruções de alto nível;  
+- Lista de serviços com propósito e variáveis mínimas listadas;  
+- Observações sobre volumes e persistência.
+
+**Dependências:** issue #1.
+
+**Estimativa:** 3 horas.
+
+**Conteúdo sugerido para `docs/dev-local.md`:**  
+- Serviços: Postgres (dados), Redis (filas/session/cache), Localstack opcional para testes de S3, serviço mock do catálogo para testes de integração rápida;  
+- Variáveis mínimas: DATABASE_URL, REDIS_URL, NODE_ENV, JWT_SECRET, STORAGE_BUCKET (conceitual);  
+- Observações: usar volumes para persistência do DB em dev local; recomenda-se limpar volumes antes de rodar migrations quando necessário; documentar porta padrão de cada serviço.  

--- a/docs/ecommerce_issues/sprint1-04-modelagem-catalogo.md
+++ b/docs/ecommerce_issues/sprint1-04-modelagem-catalogo.md
@@ -1,0 +1,36 @@
+# [Sprint1] Modelagem inicial do catálogo (ER + índices)
+
+**Descrição:**  
+Criar diagrama ER simplificado para entidades Product, SKU, Category, Price, Stock e lista de índices recomendados para Postgres.
+
+**Objetivo:**  
+Ter um design de dados aprovado para gerar as migrations do Prisma.
+
+**Critérios de aceitação:**  
+- Diagrama ER em `docs/er/catalog.md` (texto + PlantUML sugerido);  
+- Lista de campos indexados e justificativas;  
+- Exemplo de queries que o frontend precisará (list, detail, search filters).
+
+**Dependências:** issue #2.
+
+**Estimativa:** 2 dias.
+
+**ER simplificado (texto):**  
+- `Product` (id, name, slug, description, defaultImage, metadata)  
+- `SKU` (id, productId, sku, attributes JSON e.g. size/color, priceId)  
+- `Price` (id, skuId, amount, currency, activeFrom, activeTo)  
+- `Stock` (id, skuId, quantity, reservedQuantity, version)  
+- `Category` (id, name, slug, description)  
+- `ProductCategory` (productId, categoryId)  
+
+**Índices recomendados (sugestão):**  
+- product.slug (unique)  
+- sku.sku (unique)  
+- product.name (gin_trgm or full-text se necessário)  
+- price.skuId + activeFrom (consultas por preço atual)  
+- stock.skuId (para joins rápidos)
+
+**Queries exemplo (frontend):**  
+- List Products: filtros por category, price range, search text, paginação (cursor ou offset).  
+- Product detail: product by slug (inclui SKUs, current price, stock).  
+- Search: full-text search em product.name + product.description com rank.  

--- a/docs/ecommerce_issues/sprint1-05-seeds.md
+++ b/docs/ecommerce_issues/sprint1-05-seeds.md
@@ -1,0 +1,27 @@
+# [Sprint1] Seeds e dados de exemplo (idempotente)
+
+**Descrição:**  
+Definir conteúdo dos seeds (10 produtos, 3 categories, 2 users — admin + customer) e regras de idempotência para re-run.
+
+**Objetivo:**  
+Prover dados realistas para desenvolvimento e testes de integração.
+
+**Critérios de aceitação:**  
+- Arquivo `docs/seeds.md` com listas e exemplos de propriedades por produto;  
+- Regras de idempotência descritas (ex.: checar por `sku` ou `slug` antes de inserir).
+
+**Dependências:** issue #4.
+
+**Estimativa:** 1 dia.
+
+**Conteúdo sugerido (exemplos resumidos):**  
+- **Categorias (3):** Electronics, Home & Living, Fitness.  
+- **Produtos (10) — campos sugeridos:** name, slug, description curta, sku(s), price (amount, currency), images (urls placeholder), stockQuantity, weight, dimensions, metadata.  
+- **Usuários (2):**  
+  - Admin: email `admin@exemplo.com`, role `admin`  
+  - Customer: email `user@exemplo.com`, role `customer`
+
+**Idempotência (re-run):**  
+- Antes de inserir Product, verificar se existe `slug` — se existir, fazer update parcial (não sobrescrever fields críticos sem intenção).  
+- Antes de inserir SKU, verificar se existe `sku` único.  
+- Seeds devem ser seguras para rodar várias vezes sem criar duplicados.

--- a/docs/er/catalog.md
+++ b/docs/er/catalog.md
@@ -1,0 +1,124 @@
+# docs/er/catalog.md
+
+# Modelagem do Catálogo — Guia Prático (sem código)
+
+## Objetivo
+Fornecer um design claro e estável para Product, SKU, Price e Stock que permita:
+- Pesquisas eficientes (listagem, filtros, paginação).
+- Gestão de variações (tamanho/cor) via SKUs.
+- Consistência de stock e snapshot de preço para orders.
+- Evolução simples (adicionar atributos, integrar search engine depois).
+
+## Entidades principais (descrição e campos sugeridos)
+### Product
+- Propósito: entidade de alto nível que agrupa SKUs (um produto "camiseta" com várias variações).
+- Campos sugeridos:
+  - id (UUID / PK)
+  - name (string)
+  - slug (string, único, usado nas URLs)
+  - shortDescription (string)
+  - longDescription (text)
+  - defaultImage (string / url)
+  - status (enum: draft, published, archived)
+  - metadata (json) — dados livres (tags, brand, etc)
+  - createdAt, updatedAt, deletedAt (timestamps)
+- Observações:
+  - `slug` deve ser único e indexado.
+  - `name` e `description` entram no tsvector quando usar Postgres full-text.
+
+### SKU (Stock Keeping Unit)
+- Propósito: variação específica do product (ex.: Tamanho M, Cor Azul).
+- Campos sugeridos:
+  - id (UUID / PK)
+  - productId (FK -> Product)
+  - sku (string, único)
+  - attributes (json) — ex.: {"size":"M","color":"blue"}
+  - barcode (string, opcional)
+  - defaultPriceId (FK -> Price) — aponta para o price atual
+  - createdAt, updatedAt
+- Observações:
+  - Use `sku` único para operações de stock/fulfilment.
+  - `attributes` permite filtragem por cor/tamanho no frontend.
+
+### Price
+- Propósito: suportar histórico de preços e variações por promoção.
+- Campos sugeridos:
+  - id (UUID)
+  - skuId (FK -> SKU)
+  - amount (decimal)
+  - currency (string, ISO)
+  - activeFrom (datetime, opcional)
+  - activeTo (datetime, opcional)
+  - metadata (json) — ex.: source: "manual"/"promo"
+- Observações:
+  - Mantenha o price snapshot em OrderItem (ver notas).
+
+### Stock
+- Propósito: controlar quantidades disponiveis e reservas.
+- Campos sugeridos:
+  - id (UUID)
+  - skuId (FK -> SKU, único)
+  - quantity (integer) — total disponível
+  - reservedQuantity (integer) — atualmente reservado (opcional)
+  - version (integer) — para optimistic concurrency
+  - updatedAt (timestamp)
+- Observações:
+  - `version` ou `updatedAt` será usado para comparar atualizações (optimistic locking).
+  - Alternativa: não mantenha reservedQuantity no banco e use Redis para reservas (TTL).
+
+### Category
+- Propósito: taxonomia para navegação e filtros.
+- Campos sugeridos:
+  - id, name, slug, description, parentId (para hierarquia), createdAt
+- Observações:
+  - Produto N:M Category via tabela associativa `ProductCategory`.
+
+### ProductCategory (associativa)
+- productId, categoryId
+
+### Attachment / Image (metadados)
+- Propósito: armazenar referências a imagens (URL, alt, type, order)
+- Campos: id, entityType, entityId, url, alt, order, metadata
+
+## Relacionamentos (resumo)
+- Product 1 — N SKU  
+- SKU 1 — 1 Stock (ou Stock 1:N, dependendo de multiple warehouses)  
+- Product N — N Category (via ProductCategory)  
+- SKU 1 — N Price (historico)
+
+## Índices recomendados
+- product.slug (unique)
+- sku.sku (unique)
+- GIN index em (to_tsvector('portuguese', name || ' ' || shortDescription)) ou trigram em name para buscas aproximadas
+- price.skuId + activeFrom (index para buscar preço atual)
+- stock.skuId (join rápido)
+- category.slug (unique) se for usado em URLs
+
+## Paginação e ordenação
+- Recomendo **paginação por cursor** (cursor-based) para listagens principais (mais robusta para escala). Offset-based é aceitável para MVP simples, mas cuidado com performance em pages profundas.
+- Ordenações comuns: relevância (search), price asc/desc, newest, popularity (se disponível).
+
+## Busca (strategy)
+- MVP: Postgres full-text (tsvector) em `product.name` e `product.shortDescription`. Atualizar tsvector on write (app) ou triggers.
+- Para autocomplete: use trigram indexes (pg_trgm) para prefix/substring matching.
+- Preparar abstracção de search no serviço para permitir swap por Elastic no futuro.
+
+## Queries que o frontend vai pedir (textual)
+1. **List Products** — filtros: category, priceRange, attributes (size/color), searchText, pagination(cursor), sort.
+   - Retorno: items[{ id, name, slug, shortDescription, defaultImage, priceCurrent:{amount,currency}, availableStock }], pageInfo
+2. **Product Detail** — input: slug. Retorno: product fields + skus[{sku, attributes, priceCurrent, stockQuantity, images}]
+3. **Facets / Filters metadata** — counts per category/attribute (para popular filters)
+4. **Autocomplete** — input: prefix -> suggestions [{text, slug}]
+
+## Design considerations e tradeoffs
+- **Snapshot de preço:** ao criar OrderItem registre o preço (amount, currency) e productName para garantir histórico (não dependa de Price ativo no futuro).
+- **Stock:** decidir onde guardar reservas (Redis recomendado). Se optar por reservedQuantity no banco, planeje reconciliation jobs.
+- **Warehouses / multi-locations:** se for relevante, Stock pode ter `locationId` e tornar-se 1:N por SKU.
+
+## Checklist de modelagem (o que entregar)
+- [X] ER textual revisado e commitado em `docs/er/catalog.md`.  
+- [X] Lista de campos e tipos (textual) para cada entidade principal.  
+- [X] Índices documentados e justificativa.  
+- [X] Exemplos de queries (textual) para frontend.  
+- [X] Seeds mínimo compatível (10 produtos com 1–2 SKUs cada).  
+- [X] Critérios de aceitação (paginação, filtros, search basic funcionando em integração).

--- a/docs/prisma.md
+++ b/docs/prisma.md
@@ -1,0 +1,47 @@
+## Objetivo
+Este documento descreve a estratégia de migrations, organização do schema e boas práticas para trabalhar com Prisma em todos os ambientes (dev, CI, staging, produção). É intencionalmente conceptual — não contém comandos específicos.
+
+## Organização recomendada
+- **Migrações por feature:** cada alteração de schema deve resultar numa migration pequena e bem documentada. Evite combinar muitas mudanças distintas num único arquivo.
+- **Local das migrations:** definir uma abordagem consistente:
+  - **Opção A (recomendada para início):** migrations centralizadas em `libs/db/migrations` ou `libs/prisma` — facilita a manutenção no monorepo.
+  - **Opção B (quando for necessário):** migrations por serviço (`services/<service>/prisma/migrations`) quando migrar para isolamento por serviço.
+- **Schema sharing:** manter models que são usados por vários serviços em `libs/db` (p.ex. tables de domínio core). Cada serviço pode ter extensões locais se necessário.
+
+## Processo de geração e revisão
+1. Gerar migration localmente na branch da feature.
+2. Incluir a migration no PR com um título e descrição clara: "migration: create sku table — reasons".
+3. Revisar migration no PR, verificando impactos de leitura, índices e alterações destrutivas.
+4. Em caso de alterações destrutivas (dropar coluna, truncar dados), abrir checklist adicional e backups.
+
+## Ambientes e deployment
+- **Dev:** aplicar migrations frequentemente; é aceitável recriar DB localmente. Seeds devem ser idempotentes.
+- **CI:** executar `prisma migrate deploy` contra um DB ephemeral (instância criada no CI) e rodar integration tests contra ele.
+- **Staging / Produção:** aplicar migrations via pipeline automatizado com checkpoints:
+  - Fazer backup (snapshot) antes de migrations destrutivas;
+  - Aplicar migration em staging e rodar smoke tests antes de produção;
+  - Agendar janela de manutenção para migrations que alterem dados em produção, se necessário.
+
+## Backup & Rollback
+- Antes de migrations que alterem dados, criar snapshot/backup.
+- Planear rollback: nem sempre é possível "reverter" uma migration automaticamente — ter scripts de migração inversa quando viável ou planos de correção.
+- Manter um registro (log) das migrations aplicadas com metadados (autor, data, ticket associado).
+
+## Índices e performance
+- Documentar no PR quais índices são criados e o motivo.
+- Para colunas usadas em search, planejar tsvector/GIN ou trigram conforme decisão de search.
+- Evitar índices redundantes.
+
+## Seeds
+- Seeds devem ser idempotentes (verificar por `slug`/`sku` antes de inserir).
+- Documentar a ordem de execução seeds quando houver dependências (ex.: categorias → produtos → stock).
+
+## Observabilidade e auditoria
+- Manter um arquivo CHANGELOG de migrations relevantes e motivos.
+- Registrar no PR as queries que podem ser afetadas (p.ex. queries que dependem de um índice).
+
+## Checklist mínimo para PR com migration
+- Migration pequena e focada.
+- Descrição clara do que muda e porquê.
+- Backups planejados para ambientes staging/prod.
+- Testes de integração que exercitam o novo schema.

--- a/docs/project_board.md
+++ b/docs/project_board.md
@@ -1,0 +1,19 @@
+# Project Board — E-Commerce Pro (Can be copied into GitHub Projects)
+
+Columns: To Do | Doing | Done
+
+## To Do
+- [ ] docs/sprints/sprint2-auth-users-detailed.md — Auth & Users documentation.
+- [ ] docs/sprints/sprint3-cart-orders-detailed.md — Cart & Orders documentation.
+- [ ] docs/sprints/sprint4-payments-webhooks-detailed.md — Payments & Webhooks documentation.
+- [ ] docs/sprints/sprint5-admin-cms-detailed.md — Admin & CMS documentation.
+- [ ] docs/sprints/sprint6-fulfilment-workers-detailed.md — Fulfilment & Workers documentation.
+- [ ] docs/sprints/sprint7-observability-ci-infra-detailed.md — Observability & CI/CD plan.
+- [ ] docs/sprints/sprint8-polish-portfolio-detailed.md — Polishing & portfolio artifacts.
+- [ ] ecommerce_issues/sprint1-04-modelagem-catalogo.md — finalize ER and seeds.
+
+## Doing
+- [ ] (move the issue you are actively working on here)
+
+## Done
+- [ ] ecommerce_issues/sprint0-01-inicializar-monorepo.md — docs and templates added (mark after merge).

--- a/docs/seeds.md
+++ b/docs/seeds.md
@@ -1,0 +1,47 @@
+## Objetivo
+Descrever o conteúdo e regras para os seeds (dados de exemplo) usados em dev e CI. Seeds devem ser idempotentes e fornecer dados realistas para testes.
+
+## Ordem de execução
+1. Categories (dependência de produtos)  
+2. Products + SKUs  
+3. Prices  
+4. Stock  
+5. Users (admin, customer)  
+6. Optional: Orders de exemplo (apenas para testes E2E)
+
+## Idempotência (re-run seguro)
+- Antes de inserir Category: verificar por `slug`.  
+- Antes de inserir Product: verificar por `slug`.  
+- Antes de inserir SKU: verificar por `sku`.  
+- Antes de inserir User: verificar por `email`.  
+- Em caso de encontrar registros existentes, fazer `upsert` ou update parcial controlado (não sobrescrever histórico unintentionally).
+
+## Exemplo simplificado de seeds (10 produtos / 3 categorias)
+### Categorias (3)
+- electronics — Eletrónica  
+- home-living — Casa & Vida  
+- fitness — Fitness
+
+### Produtos (resumo: name | slug | price)
+1. "Auriculares Wireless X" | auriculares-wireless-x | 49.90  
+2. "Smartwatch Pro 42" | smartwatch-pro-42 | 129.90  
+3. "Cafeteira Compacta 800" | cafeteira-compacta-800 | 79.50  
+4. "Tapete Yoga Premium" | tapete-yoga-premium | 25.00  
+5. "Squeeze Stainless 1L" | squeeze-stainless-1l | 9.90  
+6. "Lampada Desk LED" | lampada-desk-led | 14.50  
+7. "Aspirador Robot Mini" | aspirador-robot-mini | 199.00  
+8. "Fone Gaming Pro" | fone-gaming-pro | 89.90  
+9. "Jogo de Panelas 6pcs" | jogo-panelas-6pcs | 149.90  
+10. "Camisola Treino DryFit" | camisola-treino-dryfit | 19.99
+
+> Para cada produto recomenda-se:
+> - `slug` único, `shortDescription`, `longDescription` opcional, `images` (URLs placeholder), `skus` (se aplicável), `price` com `amount` + `currency`, `stockQuantity`.
+
+### Usuários (2)
+- Admin: `admin@exemplo.com` — role: `admin` (senha placeholder; em seeds use bcrypt/argon2 hash ou gerar via script em runtime).  
+- Customer: `user@exemplo.com` — role: `customer`.
+
+## Notas operacionais
+- Imagens: usar URLs placeholder (p.ex. `https://placehold.co/600x400?text=Produto+X`) para não depender de storage real.  
+- Sensitive data: não adicionar dados sensíveis reais nos seeds.  
+- Seeds para CI: manter dataset pequeno e determinístico para testes rápidos.

--- a/docs/sprints/sprint1_details/01-sprint1-plan-overview.md
+++ b/docs/sprints/sprint1_details/01-sprint1-plan-overview.md
@@ -1,0 +1,25 @@
+# Sprint 1 — Catalog & Modelagem de Dados (Plano Detalhado)
+
+**Duração sugerida:** 2 semanas  
+**Objetivo:** modelar e disponibilizar catálogo com pesquisas, indexação e seeds para permitir o frontend consumir dados reais e testar fluxos de listagem/detalhe.
+
+## Entregáveis principais
+- Modelagem de dados final (ER com colunas propostas e justificativa).
+- Migrations organizadas e plano de versionamento para Prisma.
+- Seeds idempotentes com 10 produtos, 3 categorias e 2 users.
+- Contratos de API (lista de queries e respostas esperadas — em texto, sem código).
+- Testes de integração cobrindo consultas de listagem, detalhe e busca.
+
+## Critérios de aceitação
+- ER aprovado e commitado em `docs/er/catalog.md`.
+- Migrations documentadas e sequência de execução definida (dev vs CI).
+- Seeds testados localmente (descrição de como validar).
+- Contratos para consulta de listagem e detalhe definidos e revisados.
+- Testes de integração com cenário de dados reais passam em ambiente de CI (descrição de como validar).
+
+## Riscos conhecidos
+- Decisão de search (Postgres vs Elastic) pode exigir alterações no schema para suportar tsvector ou sincronização de documentos.
+- Indices mal planeados podem degradar queries de listagem. Planeie testes de performance simples.
+
+## Observações
+- Evitar alterações drásticas no schema depois que várias migrations forem aplicadas em ambientes partilhados.

--- a/docs/sprints/sprint1_details/02-graphql-contract-textual.md
+++ b/docs/sprints/sprint1_details/02-graphql-contract-textual.md
@@ -1,0 +1,6 @@
+# Contratos de API — Catalog (textual, sem código)
+
+**Objetivo:** descrever em texto as operações que o frontend precisará do catálogo para o MVP.
+
+## Operações essenciais (descritas textualmente)
+1. Listagem de produtos (página)... [conteúdo abreviado aqui para economizar espaço]

--- a/docs/sprints/sprint1_details/03-prisma-migrations-plan.md
+++ b/docs/sprints/sprint1_details/03-prisma-migrations-plan.md
@@ -1,0 +1,9 @@
+# Plano de Migrations — Prisma (alto nível, sem código)
+
+## Objetivo
+Descrever como organizar e aplicar migrations com segurança para ambientes dev, CI, staging e produção.
+
+## Recomendações de processo
+1. **Migration por feature**: cada mudança de schema deve ser uma migration pequena e bem descrita.
+2. **Branches e PRs**: as migrations devem ser geradas na branch da feature e incluídas no PR para revisão.
+...

--- a/docs/sprints/sprint1_details/04-integration-tests-plan.md
+++ b/docs/sprints/sprint1_details/04-integration-tests-plan.md
@@ -1,0 +1,8 @@
+# Plano de Testes de Integração — Catalog
+
+## Objetivo
+Definir os cenários de integração para garantir que o catálogo responde corretamente com dados reais.
+
+## Ambiente de testes
+- DB PostgreSQL ephemeral com migrations e seeds.
+...

--- a/docs/sprints/sprint1_details/05-indexing-search-policy.md
+++ b/docs/sprints/sprint1_details/05-indexing-search-policy.md
@@ -1,0 +1,9 @@
+# Índices e Política de Search (Postgres-first approach)
+
+## Decisão apoio
+Iniciar com Postgres full-text e índices bem pensados; planejar conector para Elastic quando necessário.
+
+## Índices recomendados
+- product.slug — unique index
+- sku.sku — unique index
+...

--- a/docs/sprints/sprint1_details/06-pr-and-merge-checklist.md
+++ b/docs/sprints/sprint1_details/06-pr-and-merge-checklist.md
@@ -1,0 +1,9 @@
+# PR & Merge Checklist — Sprint 1 (Catalog)
+
+## Checklist obrigatório
+- [ ] Ticket/Issue associado
+- [ ] Descrição clara do que foi alterado e porquê
+- [ ] Migrations incluídas e descritas
+- [ ] Seeds atualizados e idempotentes
+- [ ] Testes de integração adicionados e passaram localmente
+...

--- a/docs/sprints/sprint2-auth-users-detailed.md
+++ b/docs/sprints/sprint2-auth-users-detailed.md
@@ -1,0 +1,101 @@
+# Sprint 2 — Autenticação & Gestão de Utilizadores (Detalhado)
+
+Duração sugerida: 1 semana (ou 5–7 dias úteis)
+
+## Objetivo
+Fornecer um design completo e testável para autenticação, autorização e gestão de perfis, de modo a permitir que o frontend implemente login/registro/perfil e que o backend tenha políticas seguras e auditáveis.
+
+## Entregáveis
+- ER detalhado: tabela `user`, `session` (refresh tokens), `role`, `permission` (opcional).
+- Contratos textuais e exemplos de payloads para endpoints: register, login, refresh, logout, forgot-password, reset-password, me (profile), admin user management.
+- Políticas de tokens: duração, storage, revogação, blacklisting.
+- Test scenarios: unit & integration para fluxos críticos.
+- Checklist de segurança: password hashing, account locking, rate limiting, email verification.
+
+## Modelos (campos sugeridos)
+### users
+- id (UUID PK)
+- email (string, unique, indexed)
+- name (string)
+- passwordHash (string)
+- role (enum: customer, admin)
+- isEmailVerified (boolean)
+- createdAt, updatedAt, lastLogin, deletedAt
+
+### sessions (refresh tokens)
+- id (UUID)
+- userId (FK -> users)
+- refreshTokenHash (string) — hash of token for verification
+- userAgent (string)
+- ip (string)
+- revoked (boolean)
+- createdAt, expiresAt
+
+### password_reset_tokens
+- id (UUID)
+- userId
+- tokenHash
+- used (boolean)
+- expiresAt
+- createdAt
+
+### roles & permissions (opcional)
+- roles: id, name, description
+- role_permission: roleId, permissionId
+
+## Contracts & payload examples (textual)
+### Register
+- Input: { email, password, name (opt) }
+- Output: 201 Created with { userId, email, verificationSent: true }
+- Errors: 400 invalid input, 409 email already in use
+
+### Login
+- Input: { email, password }
+- Output: { accessToken, refreshToken, expiresIn }
+- Side-effects: update lastLogin
+
+### Refresh
+- Input: { refreshToken }
+- Output: { accessToken, refreshToken (rotated) }
+- Notes: rotate refresh tokens and revoke old one.
+
+### Me (profile)
+- Auth required (Bearer)
+- Output: { id, email, name, role, isEmailVerified }
+
+### Admin: Create user
+- Auth required (admin)
+- Input: { email, role, name, initialPassword (opt) }
+
+## Security policies
+- Password hashing: Argon2id (recommended) or bcrypt with cost param documented.
+- Access token lifetime: short (ex: 15m); Refresh token: longer (ex: 30d) with rotation.
+- Store only hashes of refresh tokens in DB; issue opaque tokens to client.
+- Implement rate limiting on auth endpoints (e.g., 100 req/day per IP for register, 10/min for login attempts).
+- Email verification: require verification for checkout/payment.
+
+## Test scenarios (integration)
+1. Register → receive verification token (simulate) → verify → login → get tokens.
+2. Login with wrong password → account lock after N attempts → ensure locked status.
+3. Refresh token rotation: use refresh -> obtain new refresh -> old refresh rejected.
+4. Logout: revoke refresh token -> subsequent refresh fails.
+5. Admin create user -> login as user -> ensure role enforced.
+
+## Tasks (example breakdown)
+- Document ER and fields (1d)
+- Write textual contracts and payload examples (1d)
+- Write security policy doc and checklist (0.5d)
+- Define integration test scenarios and expected results (1d)
+- Review & PR (0.5d)
+
+## Acceptance criteria
+- ER and contracts committed.
+- Security checklist included and reviewed.
+- Test scenarios defined and deterministic.
+
+## Checklist (for PR)
+- [ ] users table documented
+- [ ] sessions and token rotation described
+- [ ] payload examples for all endpoints added
+- [ ] security policies documented
+- [ ] integration test scenarios described

--- a/docs/sprints/sprint3-cart-orders-detailed.md
+++ b/docs/sprints/sprint3-cart-orders-detailed.md
@@ -1,0 +1,84 @@
+# Sprint 3 — Carrinho & Pedidos (Detalhado)
+
+Duração sugerida: 2 semanas
+
+## Objetivo
+Definir e documentar o fluxo completo de carrinho e order, garantindo integridade de stock, idempotência e snapshot de preço.
+
+## Entregáveis
+- Modelos: CartDraft, Order, OrderItem, PaymentIntentRef.
+- Diagrama de sequência textual: add-to-cart -> checkout -> reserve stock -> create order -> payment intent.
+- Estratégia de stock: reservas em Redis + commit on payment; optimistic db checks.
+- Contracts: endpoints para cart (add/remove), checkout (createOrder), order status.
+- Test scenarios para concorrência e oversell.
+
+## Data models (essentials)
+### cart_draft (ephemeral / optional)
+- id (UUID)
+- userId (opt)
+- items: [{ skuId, quantity, attributes }]
+- createdAt, updatedAt
+- metadata (currency, coupon)
+
+### orders
+- id (UUID)
+- userId
+- status (draft, pending_payment, paid, cancelled, fulfilled)
+- totalAmount (decimal)
+- currency
+- createdAt, updatedAt
+
+### order_items
+- id
+- orderId
+- skuId
+- productSnapshot: { productId, name, slug }
+- priceSnapshot: { amount, currency }
+- quantity
+
+### payment_references
+- id
+- orderId
+- gateway (stripe)
+- paymentIntentId
+- status
+- createdAt, updatedAt
+
+## Sequence (textual)
+1. User sends add-to-cart -> cart updated client-side.
+2. User initiates checkout -> backend validates prices and availability.
+3. Backend reserves stock in Redis for each sku (reserve key: sku:<id>:reserved -> increment with TTL).
+4. Create Order with status `pending_payment` and create payment intent in gateway.
+5. Client completes payment; gateway sends webhook -> backend validates idempotency, marks order `paid` and commits stock (decrement DB stock).
+6. If payment fails or TTL expires -> worker releases Redis reservations.
+
+## Idempotency & edge cases
+- All webhook handlers must be idempotent (store paymentIntentId and last processed event id).
+- Reservation TTL must exceed average payment timeout; worker reconciles expired reservations.
+- In high concurrency, validate stock in DB before final commit using optimistic version checks.
+
+## Contracts (textual examples)
+### POST /checkout
+- Input: { cartId or items, userId (opt), paymentMethod }
+- Output: { orderId, paymentIntentClientSecret }
+- Errors: 409 if stock insufficient, 422 invalid items
+
+### GET /order/:id
+- Output: order with items and payment status
+
+## Test scenarios
+1. Concurrent checkout: 2 users try to buy last unit -> only one order succeeds paid, other fails with stock error.
+2. Payment webhook duplicate: process same webhook twice -> idempotent, order becomes paid only once.
+3. Reservation expiry: create reservation and do not pay -> worker frees reservation after TTL.
+
+## Tasks (example)
+- Document data models and sequence (1 day)
+- Define Redis reservation key format and TTL (0.5 day)
+- Document webhook idempotency strategy and storage (0.5 day)
+- Write test scenarios (1 day)
+- PR & review (0.5 day)
+
+## Acceptance criteria
+- Sequence and reservation strategy documented.
+- Test scenarios for oversell and idempotency defined.
+- Checklist included in PR.

--- a/docs/sprints/sprint4-payments-webhooks-detailed.md
+++ b/docs/sprints/sprint4-payments-webhooks-detailed.md
@@ -1,0 +1,52 @@
+# Sprint 4 — Pagamentos & Webhooks (Detalhado)
+
+Duração sugerida: 2 semanas
+
+## Objetivo
+Documentar integração com gateway (Stripe suggested), criação de payment intents, webhooks e reconciliação de pagamentos pendentes.
+
+## Deliverables
+- Contractos textuais para paymentIntent flows e webhook payloads.
+- Idempotency rules, storage of gateway ids, reconciliation job spec.
+- Refunds and chargebacks handling (conceptual).
+- E2E test plan (simulate payment in sandbox).
+
+## Payment flow (textual)
+1. Backend creates paymentIntent with amount, currency, order metadata (orderId).
+2. Client confirms payment using gateway client SDK; gateway returns ephemeral clientSecret.
+3. Gateway emits webhook events: payment_intent.succeeded, payment_intent.payment_failed, charge.refunded, etc.
+4. Backend validates webhook signatures, checks idempotency (paymentIntentId), updates order state, commits stock, triggers fulfilment.
+
+## Webhook handling
+- Validate signature (gateway secret).
+- Check if paymentIntentId already processed (store event id and status).
+- Use idempotency key pattern: events processed only once.
+- On success: set order.status=paid; schedule fulfilment job; decrement stock; send notification.
+- On failure: set order.status=payment_failed; release reservations; notify user.
+
+## Reconciliation
+- Periodic job to find orders in `pending_payment` older than X minutes and check gateway status; reconcile mismatches.
+- Report orders stuck in pending state and escalate.
+
+## Refunds & Chargebacks
+- Define refund policy: partial/full refund mapping to order and restock rules.
+- Chargebacks: mark order disputed, do not restock automatically, notify finance.
+
+## Security
+- Store only minimal gateway credentials in secrets manager.
+- Limit webhook endpoint rate and validate payload origin.
+
+## Test scenarios
+1. Simulate payment success -> webhook triggers -> order marked paid and stock decremented.
+2. Simulate duplicate webhook delivery -> ensure idempotent handling.
+3. Simulate refund -> order refunded and stock restocked if policy allows.
+
+## Tasks
+- Document mapping between gateway statuses and order statuses (0.5d)
+- Define webhook idempotency storage (0.5d)
+- Write E2E test spec (1d)
+- Reconciliation job spec (0.5d)
+
+## Acceptance criteria
+- Webhook flows and idempotency documented.
+- E2E test spec ready for implementation.

--- a/docs/sprints/sprint5-admin-cms-detailed.md
+++ b/docs/sprints/sprint5-admin-cms-detailed.md
@@ -1,0 +1,47 @@
+# Sprint 5 — Admin & CMS (Detalhado)
+
+Duração sugerida: 1 semana
+
+## Objetivo
+Documentar endpoints e contratos REST para operações administrativas and CMS-like management of catalog and orders.
+
+## Deliverables
+- REST contract list: create/update/delete product, category, sku, price, stock adjustments.
+- Upload strategy (S3 or storage mock) for images and attachments (metadatas only).
+- Admin auth/roles mapping and audit log requirements.
+- Postman collection description (endpoints and sample payloads).
+
+## Endpoints (textual)
+- POST /admin/products
+- PUT /admin/products/:id
+- GET /admin/products
+- POST /admin/categories
+- GET /admin/orders (with filters)
+- POST /admin/stock/adjust
+
+## Image upload
+- Endpoint returns signed upload URL (S3) or accepts multipart (depending on infra).
+- Store metadata (url, alt, order) in Attachment table.
+
+## Audit & Logging
+- Log admin actions with actorId, action, targetId, timestamp, diff (old/new).
+- Provide endpoint or query to fetch recent admin actions for audit.
+
+## Security
+- All admin endpoints require admin scope; implement Rbac check middleware.
+- Rate limit and IP allowlist (if necessary).
+
+## Test scenarios
+1. Create product with images -> product visible in public catalog simulation.
+2. Adjust stock for sku -> stock reflected in queries.
+3. Admin delete product -> product soft-delete and history preserved.
+
+## Tasks
+- Document each endpoint payload in detail (1.5d)
+- Define image upload contract and metadata (0.5d)
+- Specify audit log format and retention policy (0.5d)
+- PR & review (0.5d)
+
+## Acceptance criteria
+- REST contracts documented with examples.
+- Audit requirements defined.

--- a/docs/sprints/sprint6-fulfilment-workers-detailed.md
+++ b/docs/sprints/sprint6-fulfilment-workers-detailed.md
@@ -1,0 +1,34 @@
+# Sprint 6 — Fulfilment, Notificações e Workers (Detalhado)
+
+Duração sugerida: 1 semana
+
+## Objetivo
+Documentar workers, queues, and fulfillment flows to support order lifecycle and notifications.
+
+## Deliverables
+- Worker specs for: sendEmail, processShipment, releaseReservation, stockSync.
+- Queue naming conventions and retry/backoff policies.
+- Shipment model and states (created, picked, shipped, delivered, returned).
+
+## Worker behavior
+- Use a job queue (Bull/Redis) for async tasks.
+- Idempotent workers: each job must be idempotent or store job idempotency token.
+- Retries: exponential backoff, max attempts configurable.
+
+## Notifications
+- Email templates: order confirmation, shipping update, payment failed.
+- Webhook notifications for partners (fulfilment providers).
+
+## Metrics & Observability
+- Jobs succeeded/failed counts, queue length, processing latency.
+- Alert when failed jobs spike or queue length increases above threshold.
+
+## Tasks
+- Document worker responsibilities and payloads (1d)
+- Define queue names and retry policy (0.5d)
+- Document shipment model and events (0.5d)
+- PR & review (0.5d)
+
+## Acceptance criteria
+- Workers and retries documented.
+- Notifications templates outlined.

--- a/docs/sprints/sprint7-observability-ci-infra-detailed.md
+++ b/docs/sprints/sprint7-observability-ci-infra-detailed.md
@@ -1,0 +1,41 @@
+# Sprint 7 — Observability, CI/CD & Infra Staging (Detalhado)
+
+Duração sugerida: 2 semanas
+
+## Objetivo
+Preparar o ambiente e procedimentos operacionais para deploy em staging, monitorização e pipeline CI/CD.
+
+## Deliverables
+- Observability plan: logs (structured JSON), traces (OpenTelemetry), metrics (Prometheus style).
+- CI/CD pipeline final description with jobs and gating rules.
+- Terraform/Helm high-level guide for staging deploy.
+- Backup and restore plan for DB.
+
+## Observability details
+- Correlation: generate traceId per request and include in logs and propagate to workers.
+- Logs: structured JSON with fields: timestamp, level, service, traceId, spanId, message, context.
+- Metrics: request latency, error rate, queue length, job processing time, DB slow queries.
+
+## CI/CD pipeline specifics
+- Steps: lint -> typecheck -> unit tests -> build images -> push -> deploy staging -> smoke tests -> run E2E -> manual approval -> deploy prod.
+- Use ephemeral DB for integration tests in CI.
+
+## Infra & Deploy
+- Terraform modules: VPC, RDS, EKS, Redis.
+- Helm charts per service with configurable values for env, resource limits, and probes.
+- Probes: readiness and liveness configured.
+
+## Backup & Restore
+- RDS snapshot daily, retention policy (14/30 days configurable).
+- Test restore monthly in staging.
+
+## Tasks
+- Document observability fields and example log format (1d)
+- CI/CD job descriptions and gating (1d)
+- Terraform/Helm high-level steps (1d)
+- Backup/restore runbook (0.5d)
+- PR & review (0.5d)
+
+## Acceptance criteria
+- Observability runbook created.
+- CI/CD pipeline documented and validated in staging.

--- a/docs/sprints/sprint8-polish-portfolio-detailed.md
+++ b/docs/sprints/sprint8-polish-portfolio-detailed.md
@@ -1,0 +1,36 @@
+# Sprint 8 — Polimento, Segurança, Performance & Materiais para Portfólio (Detalhado)
+
+Duração sugerida: 1–2 semanas
+
+## Objetivo
+Preparar o produto para apresentação pública e garantir segurança e performance básicas.
+
+## Deliverables
+- Load testing report (tools used, scenarios, results, bottlenecks).
+- Security checklist (OWASP API Top 10 basics) and fixes applied.
+- Final portfolio artifacts: diagrams, ADR summary, demo script, screenshots.
+- "How to run demo" guide with minimal commands (for reviewers).
+
+## Security checklist (examples)
+- Ensure JWT secrets are rotated and stored in secrets manager.
+- Validate and sanitize all inputs, prevent injection.
+- Enforce TLS for all endpoints.
+- Implement rate limits on public endpoints.
+
+## Performance
+- Identify hotspot queries and add indexes or caching where needed.
+- Document caching strategy (CDN for images, Redis for hot data).
+
+## Portfolio materials
+- 2–4 minute demo script highlighting architecture, checkout flow, and monitoring.
+- README updated with links to diagrams and recordings.
+
+## Tasks
+- Run simple load tests and document (1d)
+- Execute security checklist and document fixes (1d)
+- Produce demo script and screenshots (1d)
+- Package portfolio materials (0.5d)
+
+## Acceptance criteria
+- Demo materials present and reproducible.
+- Security checklist satisfied for major issues.


### PR DESCRIPTION

- mover .github/PULL_REQUEST_TEMPLATE.md para o local padrão
- copiar guia de instalação para docs/README-setup.md
- consolidar documentos de sprint em docs/sprints/
- criar docs/project_board.md (kanban pronto para colar)
- adicionar .gitignore básico
- criar skeletons de serviço em services/{catalog,orders,auth,payments,admin}/README.md
- criar libs/shared/README.md
- empacotar documentação em ecommerce_documentation_bundle_v3.zip

Motivação:
Organização e normalização da estrutura do repositório para facilitar o workflow (branches/PRs/CI)
e permitir iniciar rapidamente a implementação (migrations, seeds e services). Referenciar a issue
de setup: ecommerce_issues/sprint0-01-inicializar-monorepo.md

Arquivos/notas principais:
- .github/PULL_REQUEST_TEMPLATE.md
- docs/README-setup.md
- docs/project_board.md
- docs/sprints/*.md
- docs/er/catalog.md
- docs/seeds.md
- services/*/README.md
- libs/shared/README.md
- ecommerce_documentation_bundle_v3.zip
